### PR TITLE
fix image coordinate

### DIFF
--- a/src/main/java/pdreaders/ImageExtractor.java
+++ b/src/main/java/pdreaders/ImageExtractor.java
@@ -71,11 +71,10 @@ public class ImageExtractor extends PDFStreamEngine {
             PDXObject xobject = getResources().getXObject( objectName );
             if( xobject instanceof PDImageXObject) {
                 PDImageXObject image = (PDImageXObject)xobject;
-                int imageWidth = image.getWidth();
-                int imageHeight = image.getHeight();
                 Matrix ctmNew = getGraphicsState().getCurrentTransformationMatrix();
-                Rectangle2D.Float bbox = new Rectangle2D.Float(ctmNew.getTranslateX(), ctmNew.getTranslateY(),
-                        imageWidth, imageHeight);
+                float currentX = (float)  currentPage.getHeight() - ctmNew.getScalingFactorY();
+                Rectangle2D.Float bbox = new Rectangle2D.Float(ctmNew.getTranslateX(), currentX - ctmNew.getTranslateY(),
+                        ctmNew.getScalingFactorX(), ctmNew.getScalingFactorY());
                 PDFImage pdfImage = new PDFImage(image, bbox, currentPage, this.sourceFile.getParent());
                 this.images.add(pdfImage);
                 pdfImage.save();


### PR DESCRIPTION
Initially, the coordinates were calculated based on the size of the image and the position was set in pdf coordinates (the images are inverted), this was fixed.